### PR TITLE
[Issue-1] fix wrong rect area calculation in case of NodeEdge reverse

### DIFF
--- a/packages/abc_bloc_inspector_devtools_extension/lib/feature/flow_graph/widget/item_widget.dart
+++ b/packages/abc_bloc_inspector_devtools_extension/lib/feature/flow_graph/widget/item_widget.dart
@@ -337,11 +337,21 @@ void _drawNodeEdgeObjects(
     );
 
     if (needToDrawBoundary) {
-      final rect = Rect.fromPoints(
-        startOffset - Offset(20, textArea.height + 20),
-        endOffset + Offset(20, 20),
-      );
-      canvas.drawRect(rect, borderPaint);
+      Rect areaRect;
+
+      if (startOffset.dx > endOffset.dx) {
+        areaRect = Rect.fromPoints(
+          endOffset - Offset(20, textArea.height + 20),
+          startOffset + Offset(20, 20),
+        );
+      } else {
+        areaRect = Rect.fromPoints(
+          startOffset - Offset(20, textArea.height + 20),
+          endOffset + Offset(20, 20),
+        );
+      }
+
+      canvas.drawRect(areaRect, borderPaint);
     }
   }
 


### PR DESCRIPTION
- Cause : 
The NodeEdge has a reverse arrow.(startOffset.dx > endOffset.dx)
In that case, the rect calculation is wrong.
![image](https://github.com/user-attachments/assets/9d4b3128-aabb-4705-b429-ff38253b6182)
